### PR TITLE
updating naming used for loop

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ resource "azurerm_network_security_group" "nsg" {
 #############################
 
 resource "azurerm_network_security_rule" "predefined_rules" {
-  for_each                                   = { for idx, rule in var.predefined_rules : lookup(rule, "name", "rule_${idx}") => merge(rule, { _index = idx }) }
+  for_each                                   = { for idx, rule in var.predefined_rules : lookup(rule, "name", "${idx}") => merge(rule, { _index = idx }) }
   name                                       = lookup(each.value, "name")
   priority                                   = lookup(each.value, "priority", 4096 - length(var.predefined_rules) + each.value._index)
   direction                                  = element(var.rules[lookup(each.value, "name")], 0)
@@ -42,7 +42,7 @@ resource "azurerm_network_security_rule" "predefined_rules" {
 #############################
 
 resource "azurerm_network_security_rule" "custom_rules" {
-  for_each                                   = { for idx, rule in var.custom_rules : lookup(rule, "name", "custom_rule_${idx}") => rule }
+  for_each                                   = { for idx, rule in var.custom_rules : lookup(rule, "name", "${idx}") => rule }
   name                                       = lookup(each.value, "name", "default_rule_name")
   priority                                   = lookup(each.value, "priority")
   direction                                  = lookup(each.value, "direction", "Any")


### PR DESCRIPTION
<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-network-security-group .
$ docker run --rm azure-network-security-group /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #000

Changes proposed in the pull request:
https://tools.hmcts.net/jira/browse/DTSPO-27522

Changing naming convention.
